### PR TITLE
Fix errorCorrection prop forwarding

### DIFF
--- a/.changeset/sixty-cobras-repair.md
+++ b/.changeset/sixty-cobras-repair.md
@@ -2,4 +2,4 @@
 "cuer": patch
 ---
 
-Prevents React warning by removing the unintended forwarding of the `errorCorrection` prop to SVG elements used by the QRCode component.
+Fixed unintended forwarding of the `errorCorrection` prop to SVG elements used by the QRCode component to prevent React warning.

--- a/.changeset/sixty-cobras-repair.md
+++ b/.changeset/sixty-cobras-repair.md
@@ -1,0 +1,5 @@
+---
+"cuer": patch
+---
+
+Prevents React warning by removing the unintended forwarding of the `errorCorrection` prop to SVG elements used by the QRCode component.

--- a/src/Cuer.tsx
+++ b/src/Cuer.tsx
@@ -83,7 +83,14 @@ export namespace Cuer {
    * @returns A {@link React.ReactNode}
    */
   export function Root(props: Root.Props) {
-    const { children, size = '100%', value, version, ...rest } = props
+    const {
+      children,
+      size = '100%',
+      value,
+      version,
+      errorCorrection,
+      ...rest
+    } = props
 
     // Check if the children contain an `Arena` component.
     const hasArena = React.useMemo(
@@ -105,14 +112,14 @@ export namespace Cuer {
 
     // Create the QR code.
     const qrcode = React.useMemo(() => {
-      let errorCorrection = props.errorCorrection
+      let ecl = errorCorrection
       // If the QR code has an arena, use a higher error correction level.
-      if (hasArena && errorCorrection === 'low') errorCorrection = 'medium'
+      if (hasArena && errorCorrection === 'low') ecl = 'medium'
       return QrCode.create(value, {
-        errorCorrection,
+        errorCorrection: ecl,
         version,
       })
-    }, [value, hasArena, props.errorCorrection, version])
+    }, [value, hasArena, errorCorrection, version])
 
     const cellSize = 1
     const edgeSize = qrcode.edgeLength * cellSize


### PR DESCRIPTION
## Summary
- avoid passing `errorCorrection` to `<svg>` in `Cuer.Root`
- simplify internal errorCorrection handling

## Testing
- `pnpm check`
- `pnpm check:types`


------
https://chatgpt.com/codex/tasks/task_e_684a48bc14bc8325b5133ea57734a150